### PR TITLE
Allow Animations, onPressIn/Out, and Global Button Styles

### DIFF
--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -112,7 +112,7 @@ class ButtonComponent extends Component {
 
     if (type === 'primary') {
       content = (
-        <LinearGradient
+        <Animated.LinearGradient
           start={gradientStart}
           end={gradientEnd}
           colors={backgroundColors}
@@ -120,26 +120,26 @@ class ButtonComponent extends Component {
           style={[styles.button, shape, currentButtonState.buttonStyle]}
         >
           {this.renderButton({ textStyle: styles.text })}
-        </LinearGradient>
+        </Animated.LinearGradient>
       );
     } else {
       const border = type === 'border' && styles.border;
       content = (
-        <View style={[styles.button, border, shape, currentButtonState.buttonStyle]}>
+        <Animated.View style={[styles.button, border, shape, currentButtonState.buttonStyle]}>
           {this.renderButton({ textStyle: styles.secondaryText })}
-        </View>
+        </Animated.View>
       );
     }
 
     return (
-      <Animated.TouchableOpacity
+      <TouchableOpacity
         accessibilityTraits="button"
         onPress={currentButtonState.onPress}
         activeOpacity={0.9}
         style={[styles.container, { width: buttonWidth, height: buttonHeight }, this.props.style]}
       >
         {content}
-      </Animated.TouchableOpacity>
+      </TouchableOpacity>
     );
   }
 }

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -137,6 +137,8 @@ class ButtonComponent extends Component {
       <TouchableOpacity
         accessibilityTraits="button"
         onPress={currentButtonState.onPress}
+        onPressIn={currentButtonState.onPressIn}
+        onPressOut={currentButtonState.onPressOut}
         activeOpacity={0.9}
         style={[styles.container, { width: buttonWidth, height: buttonHeight }, this.props.style]}
       >

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -119,7 +119,7 @@ class ButtonComponent extends Component {
           end={gradientEnd}
           colors={backgroundColors}
           collapsable={false}
-          style={[styles.button, shape, currentButtonState.buttonStyle]}
+          style={[styles.button, shape, this.props.buttonStyle, currentButtonState.buttonStyle]}
         >
           {this.renderButton({ textStyle: styles.text })}
         </AnimatedLinearGradient>
@@ -127,7 +127,7 @@ class ButtonComponent extends Component {
     } else {
       const border = type === 'border' && styles.border;
       content = (
-        <Animated.View style={[styles.button, border, shape, currentButtonState.buttonStyle]}>
+        <Animated.View style={[styles.button, border, shape, this.props.buttonStyle, currentButtonState.buttonStyle]}>
           {this.renderButton({ textStyle: styles.secondaryText })}
         </Animated.View>
       );

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { StyleSheet, View, TouchableOpacity } from 'react-native';
+import { StyleSheet, View, TouchableOpacity, Animated } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import Button from './common/Button';
 
@@ -132,14 +132,14 @@ class ButtonComponent extends Component {
     }
 
     return (
-      <TouchableOpacity
+      <Animated.TouchableOpacity
         accessibilityTraits="button"
         onPress={currentButtonState.onPress}
         activeOpacity={0.9}
         style={[styles.container, { width: buttonWidth, height: buttonHeight }, this.props.style]}
       >
         {content}
-      </TouchableOpacity>
+      </Animated.TouchableOpacity>
     );
   }
 }

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -28,6 +28,8 @@ const defaultProps = {
   height: 50,
 };
 
+const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
+
 class ButtonComponent extends Component {
   static propTypes = propTypes;
   static defaultProps = defaultProps;
@@ -112,7 +114,7 @@ class ButtonComponent extends Component {
 
     if (type === 'primary') {
       content = (
-        <Animated.LinearGradient
+        <AnimatedLinearGradient
           start={gradientStart}
           end={gradientEnd}
           colors={backgroundColors}
@@ -120,7 +122,7 @@ class ButtonComponent extends Component {
           style={[styles.button, shape, currentButtonState.buttonStyle]}
         >
           {this.renderButton({ textStyle: styles.text })}
-        </Animated.LinearGradient>
+        </AnimatedLinearGradient>
       );
     } else {
       const border = type === 'border' && styles.border;

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -16,6 +16,8 @@ const propTypes = {
   style: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
   progressSize: PropTypes.number,
   onPress: PropTypes.func,
+  onPressIn: PropTypes.func,
+  onPressOut: PropTypes.func,
 };
 
 const defaultProps = {
@@ -136,9 +138,9 @@ class ButtonComponent extends Component {
     return (
       <TouchableOpacity
         accessibilityTraits="button"
-        onPress={currentButtonState.onPress}
-        onPressIn={currentButtonState.onPressIn}
-        onPressOut={currentButtonState.onPressOut}
+        onPress={currentButtonState.onPress || this.props.onPress}
+        onPressIn={currentButtonState.onPressIn || this.props.onPressIn}
+        onPressOut={currentButtonState.onPressOut || this.props.onPressOut}
         activeOpacity={0.9}
         style={[styles.container, { width: buttonWidth, height: buttonHeight }, this.props.style]}
       >


### PR DESCRIPTION
Hi!
I recently used this component in a project of mine and had to make a few changes to suit my applications requirements.

- I have added Animated to both the final buttons `View` or the `LinearGradient`, depending on button type as I needed to shrink the buttons size on press.
- In order to have the press properly respond to my tap I exposed `onPressIn` and `onPressOut` to allow more control of the interaction.
- I included the `this.props.buttonStyle` before the `currentButtonState.buttonStyle` to allow a base style with state specific overrides.
- Similarly, `onPress`, `onPressIn` and `onPressOut` can optionally be supplied as a prop, allowing a default function to be set and be overridden by `currentButtonState`.

Thanks for this component, the bit of animation in it really helps bring it to life!


