### PR TITLE
Clean up imports for compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 import ButtonComponent from './src/ButtonComponent';
 
-export Colors from './src/common/Colors';
-export AnimatedButton from './src/common/Button';
-export InnerButton from './src/common/InnerButton';
+export * from './src/common/Button';
+export * from './src/common/InnerButton';
 
-export CircleButton from './src/CircleButton';
-export RoundButton from './src/RoundButton';
-export RectangleButton from './src/RectangleButton';
+export * from './src/CircleButton';
+export * from './src/RoundButton';
+export * from './src/RectangleButton';
 export default ButtonComponent;

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-import ButtonComponent from './src/ButtonComponent';
-
 export * from './src/common/Button';
 export * from './src/common/InnerButton';
 
 export * from './src/CircleButton';
 export * from './src/RoundButton';
 export * from './src/RectangleButton';
-export default ButtonComponent;
+export default './src/ButtonComponent';

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
+import { ButtonComponent } from './src/ButtonComponent'
 export * from './src/common/Button';
 export * from './src/common/InnerButton';
 
 export * from './src/CircleButton';
 export * from './src/RoundButton';
 export * from './src/RectangleButton';
-export default './src/ButtonComponent';
+export default ButtonComponent;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "2.2.3",
-    "eslint-plugin-react": "^6.8.0"
+    "eslint-plugin-react": "^6.8.0",
+    "prop-types": "^15.5.10"
   }
 }

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -70,7 +70,7 @@ const defaultProps = {
   gradientLocations: null,
 };
 
-class ButtonComponent extends Component {
+export class ButtonComponent extends Component {
   static propTypes = propTypes;
   static defaultProps = defaultProps;
 
@@ -191,5 +191,3 @@ class ButtonComponent extends Component {
     );
   }
 }
-
-export default ButtonComponent;

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'
 import { StyleSheet, View, TouchableOpacity } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { Button } from './common/Button';
@@ -54,8 +55,8 @@ const propTypes = {
   gradientEnd: PropTypes.object,
   gradientLocations: PropTypes.array,
   backgroundColors: PropTypes.array,
-  buttonStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
-  style: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
+  buttonStyle: View.propTypes.style,
+  style: TouchableOpacity.propTypes.style,
   progressSize: PropTypes.number,
   onPress: PropTypes.func,
 };

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { StyleSheet, View, TouchableOpacity } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
-import Button from './common/Button';
+import { Button } from './common/Button';
 import configButtonStatesAnimation from './configButtonStatesAnimation';
 
 const styles = StyleSheet.create({

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -3,6 +3,7 @@ import { StyleSheet, View, TouchableOpacity } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { Button } from './common/Button';
 import configButtonStatesAnimation from './configButtonStatesAnimation';
+import _ from 'lodash'
 
 const styles = StyleSheet.create({
   container: {
@@ -78,7 +79,7 @@ export class ButtonComponent extends Component {
     if (this.props.image !== nextProps.image) return true;
     if (this.props.text !== nextProps.text) return true;
     if (this.props.states && this.props.buttonState !== nextProps.buttonState) return true;
-    if (this.props.states && this.props.states[this.props.buttonState].progressFill) return true;
+    if (nextProps.states && !_(nextProps.states).isEqual(this.props.states)) return true;
     return false;
   }
 

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -56,7 +56,7 @@ const propTypes = {
   gradientLocations: PropTypes.array,
   backgroundColors: PropTypes.array,
   buttonStyle: View.propTypes.style,
-  style: TouchableOpacity.propTypes.style,
+  style: View.propTypes.style,
   progressSize: PropTypes.number,
   onPress: PropTypes.func,
 };

--- a/src/CircleButton.js
+++ b/src/CircleButton.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import ButtonComponent from './ButtonComponent';
 
-export default function CircleButton(props) {
+export const CircleButton = (props) => {
   const buttonSize = props.size;
   const progressSize = buttonSize;
   const textInsideProgress = props.states[props.buttonState].progress;

--- a/src/CircleButton.js
+++ b/src/CircleButton.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types'
 import { ButtonComponent } from './ButtonComponent';
 
 export const CircleButton = (props) => {

--- a/src/CircleButton.js
+++ b/src/CircleButton.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import ButtonComponent from './ButtonComponent';
+import { ButtonComponent } from './ButtonComponent';
 
 export const CircleButton = (props) => {
   const buttonSize = props.size;

--- a/src/RectangleButton.js
+++ b/src/RectangleButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ButtonComponent from './ButtonComponent';
 
-export default function RectangleButton(props) {
+export const RectangleButton = (props) => {
   const progressSize = props.height / 2;
 
   return (

--- a/src/RectangleButton.js
+++ b/src/RectangleButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ButtonComponent from './ButtonComponent';
+import { ButtonComponent } from './ButtonComponent';
 
 export const RectangleButton = (props) => {
   const progressSize = props.height / 2;

--- a/src/RoundButton.js
+++ b/src/RoundButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ButtonComponent from './ButtonComponent';
 
-export default function RoundButton(props) {
+export const RoundButton = (props) => {
   const progressSize = props.height / 2;
 
   return (

--- a/src/RoundButton.js
+++ b/src/RoundButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ButtonComponent from './ButtonComponent';
+import { ButtonComponent } from './ButtonComponent';
 
 export const RoundButton = (props) => {
   const progressSize = props.height / 2;

--- a/src/common/Button.js
+++ b/src/common/Button.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import { PropTypes } from 'prop-types'
 import { View, Animated } from 'react-native';
 import _ from 'lodash';
 import { InnerButton } from './InnerButton';

--- a/src/common/Button.js
+++ b/src/common/Button.js
@@ -9,7 +9,7 @@ const propTypes = {
   buttonState: PropTypes.string,
 };
 
-class Button extends Component {
+export class Button extends Component {
   static propTypes = propTypes;
 
   constructor(props) {
@@ -93,5 +93,3 @@ class Button extends Component {
     );
   }
 }
-
-export default Button;

--- a/src/common/Button.js
+++ b/src/common/Button.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { View, Animated } from 'react-native';
 import _ from 'lodash';
-import InnerButton from './InnerButton';
+import { InnerButton } from './InnerButton';
 
 const propTypes = {
   ...InnerButton.propTypes,

--- a/src/common/Button.js
+++ b/src/common/Button.js
@@ -27,14 +27,6 @@ export class Button extends Component {
     }
   }
 
-  shouldComponentUpdate(nextProps) {
-    const { states, buttonState } = nextProps;
-    if (states) {
-      return !!states[buttonState].progress;
-    }
-    return true;
-  }
-
   createAnimation({ opacity, transform }) {
     const animation = {};
 

--- a/src/common/InnerButton.js
+++ b/src/common/InnerButton.js
@@ -87,7 +87,7 @@ const defaultProps = {
   spinnerColor: '#ffffff',
 };
 
-class InnerButton extends Component {
+export class InnerButton extends Component {
   static propTypes = propTypes;
   static defaultProps = defaultProps;
 
@@ -186,5 +186,3 @@ class InnerButton extends Component {
     );
   }
 }
-
-export default InnerButton;

--- a/src/common/InnerButton.js
+++ b/src/common/InnerButton.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'
 import { View, Text, Animated, StyleSheet, Image } from 'react-native';
 import { AnimatedCircularProgress } from 'react-native-circular-progress';
 import Spinner from 'react-native-spinkit';

--- a/src/configButtonStatesAnimation.js
+++ b/src/configButtonStatesAnimation.js
@@ -1,4 +1,4 @@
-function configButtonTextAnimation(height, index) {
+const configButtonTextAnimation = (height, index) => {
   const textAnimConfig = {};
   const opacity = { inputRange: [], outputRange: [] };
   const translateY = { inputRange: [], outputRange: [] };
@@ -19,7 +19,7 @@ function configButtonTextAnimation(height, index) {
   return textAnimConfig;
 }
 
-function configButtonImageAnimation(height, index) {
+const configButtonImageAnimation = (height, index) => {
   const imageAnimConfig = {};
   const opacity = { inputRange: [], outputRange: [] };
   const translateY = { inputRange: [], outputRange: [] };
@@ -39,7 +39,7 @@ function configButtonImageAnimation(height, index) {
   return imageAnimConfig;
 }
 
-function configButtonProgressAnimation(height, index) {
+const configButtonProgressAnimation = (height, index) => {
   const progressAnimConfig = {};
   const opacity = { inputRange: [], outputRange: [] };
   const translateY = { inputRange: [], outputRange: [] };
@@ -52,7 +52,7 @@ function configButtonProgressAnimation(height, index) {
   return progressAnimConfig;
 }
 
-function configButtonStatesAnimation(buttonsStates, height) {
+const configButtonStatesAnimation = (buttonsStates, height) => {
   const addedAnimtionConfigButtonStates = {};
   const stateNames = Object.keys(buttonsStates);
   for (let i = 0; i < stateNames.length; i += 1) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,10 @@ art@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/art/-/art-0.10.1.tgz#38541883e399225c5e193ff246e8f157cf7b2146"
 
+asap@~2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
+
 babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -617,6 +621,10 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -680,6 +688,12 @@ doctrine@1.5.0, doctrine@^1.2.2:
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
 
 es-abstract@^1.7.0:
   version "1.7.0"
@@ -903,6 +917,18 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -1003,6 +1029,10 @@ has@^1.0.1:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
+
+iconv-lite@~0.4.13:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
 
 ignore@^3.2.0:
   version "3.2.2"
@@ -1108,6 +1138,10 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
@@ -1115,6 +1149,13 @@ is-symbol@^1.0.1:
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 js-tokens@^3.0.0:
   version "3.0.1"
@@ -1167,7 +1208,7 @@ lodash@^4.0.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -1210,6 +1251,13 @@ mute-stream@0.0.5:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+node-fetch@^1.0.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -1311,6 +1359,19 @@ process@~0.5.1:
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+
+promise@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
+  dependencies:
+    asap "~2.0.3"
+
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 react-deep-force-update@^1.0.0:
   version "1.0.1"
@@ -1420,6 +1481,10 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
 shelljs@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
@@ -1510,6 +1575,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+ua-parser-js@^0.7.9:
+  version "0.7.12"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
+
 user-home@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
@@ -1519,6 +1588,10 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
react-native packager was erroring out for me when using this module, due to the invalid export syntax in index.js.

This PR fixes that by standardizing the export syntax for ES6. 