### PR TITLE
Support for RN >= 0.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "babel-preset-react-native-stage-0": "^1.0.1",
     "lodash": "^4.17.2",
-    "react-native-circular-progress": "github:jacklam718/react-native-circular-progress#v0.0.8",
+    "react-native-circular-progress": "cconstantinescu/react-native-circular-progress",
     "react-native-linear-gradient": "^2.0.0",
     "react-native-spinkit": "^1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-button-component",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "A Beautiful, Customizable React Native Button component for iOS & Android",
   "main": "index.js",
   "directories": {

--- a/src/ButtonComponent.js
+++ b/src/ButtonComponent.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { StyleSheet, View, TouchableOpacity } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import Button from './common/Button';

--- a/src/CircleButton.js
+++ b/src/CircleButton.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ButtonComponent from './ButtonComponent';
 
 export default function CircleButton(props) {

--- a/src/common/Button.js
+++ b/src/common/Button.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View, Animated } from 'react-native';
 import _ from 'lodash';
 import InnerButton from './InnerButton';

--- a/src/common/InnerButton.js
+++ b/src/common/InnerButton.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View, Text, Animated, StyleSheet, Image } from 'react-native';
 import { AnimatedCircularProgress } from 'react-native-circular-progress';
 import Spinner from 'react-native-spinkit';


### PR DESCRIPTION
In React 16 used by RN >= 0.46 , React did away with PropTypes from React ( https://github.com/facebook/react-native/commit/8e9322c65e751dc8e7512874e03e7c4349a28b93 ) .

This commit uses the new prop-types module introduced.