### PR TITLE
point to react-native-button-component on link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ So I recommend you should use CircleButton, RoundButton, RectangleButton, rather
 
 ## Installation
 1. `npm install --save react-native-button-component`
-2. `react-native link`
+2. `react-native link react-native-button-component`
 
 ##### Note
 If you didn't see this item `libART.a` under the `Link Binary With Libraries` or you get this error `No component found for view with name "ARTSurfaceView"`


### PR DESCRIPTION
best practice is to point to specific pkg to avoid side effects